### PR TITLE
🚑️ Remove problem with error responses without entities or result

### DIFF
--- a/Bricknode.Soap.Sdk/Bricknode.Soap.Sdk.csproj
+++ b/Bricknode.Soap.Sdk/Bricknode.Soap.Sdk.csproj
@@ -7,7 +7,7 @@
     <ApplicationIcon />
 
     <!--Nuget metadata starts here-->
-    <PackageVersion>6.3.0</PackageVersion>
+    <PackageVersion>6.3.1</PackageVersion>
     <PackageId>Bricknode.Soap.Sdk</PackageId>
     <Title>Bricknode SOAP SDK</Title>
     <Authors>Bricknode</Authors>

--- a/Bricknode.Soap.Sdk/Bricknode.Soap.Sdk.csproj
+++ b/Bricknode.Soap.Sdk/Bricknode.Soap.Sdk.csproj
@@ -7,7 +7,7 @@
     <ApplicationIcon />
 
     <!--Nuget metadata starts here-->
-    <PackageVersion>6.3.1</PackageVersion>
+    <PackageVersion>6.3.0</PackageVersion>
     <PackageId>Bricknode.Soap.Sdk</PackageId>
     <Title>Bricknode SOAP SDK</Title>
     <Authors>Bricknode</Authors>

--- a/Bricknode.Soap.Sdk/Services/BfsAccountService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsAccountService.cs
@@ -38,7 +38,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -59,7 +59,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -84,7 +84,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -107,7 +107,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsAllocationProfileService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsAllocationProfileService.cs
@@ -40,7 +40,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -62,7 +62,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -87,7 +87,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsAssetService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsAssetService.cs
@@ -39,7 +39,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -66,7 +66,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -87,7 +87,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -114,7 +114,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -141,7 +141,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -162,7 +162,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -187,7 +187,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -215,7 +215,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -237,7 +237,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsBusinessEventService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsBusinessEventService.cs
@@ -39,7 +39,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsCountryService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsCountryService.cs
@@ -32,7 +32,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsCurrencyService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsCurrencyService.cs
@@ -38,7 +38,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -61,7 +61,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsDealService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsDealService.cs
@@ -38,7 +38,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsInstructionService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsInstructionService.cs
@@ -41,7 +41,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -65,7 +65,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -89,7 +89,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsInsuranceService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsInsuranceService.cs
@@ -40,7 +40,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -67,7 +67,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -89,7 +89,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -114,7 +114,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -141,7 +141,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -163,7 +163,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -188,7 +188,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -215,7 +215,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -236,7 +236,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -261,7 +261,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsLegalEntitiesService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsLegalEntitiesService.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using BfsApi;
 using Bricknode.Soap.Sdk.Configuration;
 using Bricknode.Soap.Sdk.Services.Bases;
@@ -40,7 +39,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -61,7 +60,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -86,7 +85,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -107,7 +106,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -130,7 +129,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -153,7 +152,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -176,7 +175,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsMessageService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsMessageService.cs
@@ -36,7 +36,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -57,7 +57,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -82,7 +82,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsNoteService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsNoteService.cs
@@ -36,7 +36,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -57,7 +57,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -82,7 +82,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsOrderService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsOrderService.cs
@@ -40,7 +40,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -66,7 +66,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -87,7 +87,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -112,7 +112,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -140,7 +140,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -163,7 +163,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -184,7 +184,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -208,7 +208,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -261,7 +261,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -288,7 +288,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -310,7 +310,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -332,7 +332,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -360,7 +360,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -384,7 +384,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -408,7 +408,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -432,7 +432,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -454,7 +454,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -476,7 +476,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -498,7 +498,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -528,7 +528,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -550,7 +550,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -652,7 +652,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -676,7 +676,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -698,7 +698,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -725,7 +725,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -747,7 +747,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -772,7 +772,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -847,7 +847,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -868,7 +868,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -894,7 +894,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -915,7 +915,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -984,7 +984,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -1005,7 +1005,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsPowerOfAttorneyService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsPowerOfAttorneyService.cs
@@ -40,7 +40,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -63,7 +63,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -84,7 +84,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsPriceService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsPriceService.cs
@@ -38,7 +38,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsReservationService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsReservationService.cs
@@ -37,7 +37,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -59,7 +59,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsTaskService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsTaskService.cs
@@ -35,7 +35,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -56,7 +56,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -81,7 +81,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsTaxService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsTaxService.cs
@@ -38,7 +38,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -59,7 +59,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -85,7 +85,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsTransactionNoteService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsTransactionNoteService.cs
@@ -36,7 +36,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsTransactionService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsTransactionService.cs
@@ -40,7 +40,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -64,7 +64,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -108,7 +108,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsTransferReceiverService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsTransferReceiverService.cs
@@ -40,7 +40,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -62,7 +62,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -87,7 +87,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsTrsService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsTrsService.cs
@@ -38,7 +38,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsWebhookService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsWebhookService.cs
@@ -39,7 +39,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -62,7 +62,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -85,7 +85,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -106,7 +106,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;  
         }
@@ -127,7 +127,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }

--- a/Bricknode.Soap.Sdk/Services/BfsWhiteLabelService.cs
+++ b/Bricknode.Soap.Sdk/Services/BfsWhiteLabelService.cs
@@ -39,7 +39,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Result.ToArray<EntityBase>());
+            LogErrors(response.Result);
 
             return response;
         }
@@ -60,7 +60,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }
@@ -85,7 +85,7 @@ namespace Bricknode.Soap.Sdk.Services
 
             if (ValidateResponse(response)) return response;
 
-            LogErrors(response.Entities.ToArray<EntityBase>());
+            LogErrors(response.Entities);
 
             return response;
         }


### PR DESCRIPTION
The idea is simple, the SDK contains an unfortunate problem with error responses, basically in cases when request failed on the server-side and the response contains no entities the SDK fails on a line where we trying to log errors for the entities because we always call `entities.ToArray()` method on a null object.